### PR TITLE
feat: Key Vaultにシークレットを登録するワークフローを追加

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -85,3 +85,12 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           ARM_USE_OIDC: true
+
+      - name: Register Secrets to Key Vault
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: ./scripts/set-secrets.sh
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: true

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "KEY_VAULT_NAME" {
+  value = azurerm_key_vault.this.name
+}
+
 output "STORAGE_ACCOUNT_PRIMARY_KEY" {
   value     = azurerm_storage_account.this.primary_access_key
   sensitive = true

--- a/scripts/set-secrets.sh
+++ b/scripts/set-secrets.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get Terraform outputs
+KEY_VAULT_NAME=$(terraform output -raw KEY_VAULT_NAME)
+STORAGE_ACCOUNT_PRIMARY_KEY=$(terraform output -raw STORAGE_ACCOUNT_PRIMARY_KEY)
+
+# Define secrets to register (key:value pairs)
+SECRETS=(
+    "STORAGE-ACCOUNT-PRIMARY-KEY:$STORAGE_ACCOUNT_PRIMARY_KEY"
+    "TEST-SECRET:my-test-value"
+)
+
+echo "Registering secrets to Key Vault: $KEY_VAULT_NAME"
+
+# Register each secret to Key Vault
+for secret in "${SECRETS[@]}"; do
+    secret_name="${secret%%:*}"
+    secret_value="${secret##*:}"
+
+    # Check if secret already exists
+    if az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name "$secret_name" --output none 2>/dev/null; then
+        echo "✓ Secret $secret_name already exists, skipping"
+    else
+        az keyvault secret set --vault-name "$KEY_VAULT_NAME" --name "$secret_name" --value "$secret_value" --output none
+        echo "✓ Secret $secret_name registered"
+    fi
+done
+
+echo "Secrets registered to Key Vault successfully"

--- a/variables.tf
+++ b/variables.tf
@@ -111,9 +111,13 @@ variable "role_assignment" {
       target_identity      = "gha"
       role_definition_name = "Owner"
     }
-    ght_storage_blob_data_contributor = {
+    gha_storage_blob_data_contributor = {
       target_identity      = "gha"
       role_definition_name = "Storage Blob Data Contributor"
+    }
+    gha_key_vault_secrets_officer = {
+      target_identity      = "gha"
+      role_definition_name = "Key Vault Secrets Officer"
     }
   }
 }


### PR DESCRIPTION
## 概要
mainブランチにpush（マージ）された際に、Terraformで作成されたKey Vaultに自動でシークレットを登録するワークフローを追加しました。

## 変更内容

### GitHub Actions ワークフロー
- `.github/workflows/terraform.yml`にKey Vaultシークレット登録ステップを追加
- terraform applyの後に`scripts/set-secrets.sh`を実行
- mainブランチへのpush時のみ実行される条件付き実行

### シェルスクリプト
- `scripts/set-secrets.sh`を新規作成
- メンテナンス性を重視した設計：
  - シークレットの定義を配列で管理
  - 新しいシークレットは配列に1行追加するだけで対応可能
- 冪等性を保証：
  - 既存シークレットの存在確認
  - 存在する場合はスキップ、新規の場合のみ登録
- セキュリティ対応：
  - 機密情報の標準出力への露出を防止
  - `--output none`でazコマンドの出力を抑制

### Terraform設定
- `outputs.tf`にKEY_VAULT_NAMEアウトプットを追加
- `variables.tf`にKey Vault Secrets Officer権限を追加
- GitHub ActionsのマネージドIDにKey Vaultへの書き込み権限を付与

## アーキテクチャ図

```mermaid
flowchart TD
    A[GitHub Push to main] --> B[GitHub Actions Workflow]
    B --> C[Terraform Apply]
    C --> D[scripts/set-secrets.sh]
    D --> E[terraform output -raw]
    E --> F[Get KEY_VAULT_NAME]
    E --> G[Get STORAGE_ACCOUNT_PRIMARY_KEY]
    F --> H[Azure Key Vault]
    G --> I[Check Secret Exists?]
    I -->|No| J[az keyvault secret set]
    I -->|Yes| K[Skip Registration]
    J --> H
    K --> L[Complete]
    J --> L
    
    subgraph "Azure Resources"
        H[Key Vault]
        M[Storage Account]
    end
    
    subgraph "Authentication"
        N[Azure OIDC]
        O[Managed Identity]
        P[Key Vault Secrets Officer Role]
    end
    
    B -.-> N
    N -.-> O
    O -.-> P
    P -.-> H
    
    style H fill:#e1f5fe
    style D fill:#f3e5f5
    style I fill:#fff3e0
```

## テスト手順

### 1. ローカル環境でのテスト
```bash
# Azure CLIにログイン
az login

# スクリプトの動作確認
./scripts/set-secrets.sh

# 冪等性の確認（再実行）
./scripts/set-secrets.sh
```

### 2. CI/CD環境でのテスト
- [ ] mainブランチへのマージ後、GitHub Actionsが正常に実行される
- [ ] terraform applyが成功する
- [ ] set-secrets.shが実行される
- [ ] Key Vaultにシークレットが登録される
- [ ] 再実行時にスキップ処理が動作する

### 3. 確認項目
- [ ] GitHub ActionsのログにSTORAGE_ACCOUNT_PRIMARY_KEY等の機密情報が表示されない
- [ ] Azure Key Vaultにstorage-account-primary-keyシークレットが作成される
- [ ] 同じワークフローを複数回実行してもエラーが発生しない

## 関連Issue
#[Issue番号]

## 追加情報
- シェルスクリプトは最小限の実装から開始し、今後必要に応じて機能拡張予定
- 新しいシークレットを追加する場合は、`scripts/set-secrets.sh`のSECRETS配列に1行追加するだけ
- ローカル環境とCI環境の両方で動作するよう設計