### PR TITLE
TrivyセキュリティスキャンをTerraformワークフローに追加

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  security-events: write
 
 defaults:
   run:
@@ -70,9 +71,16 @@ jobs:
       with:
         scan-type: 'config'
         scan-ref: '.'
-        format: 'table'
+        format: 'sarif'
+        output: 'trivy-results.sarif'
         exit-code: '1'
         severity: 'CRITICAL,HIGH'
+
+    - name: Upload Trivy results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: 'trivy-results.sarif'
 
   terraform:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -75,6 +75,7 @@ jobs:
         output: 'trivy-results.sarif'
         exit-code: '1'
         severity: 'CRITICAL,HIGH'
+        limit-severities-for-sarif: true
 
     - name: Upload Trivy results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -60,7 +60,7 @@ jobs:
   trivy:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: tflint
+    # needs: tflint
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -60,7 +60,6 @@ jobs:
   trivy:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # needs: tflint
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,11 +7,13 @@ on:
       - main
     paths:
       - "**/*.tf"
+      - .github/workflows/*.y?ml
   pull_request:
     branches:
       - main
     paths:
       - "**/*.tf"
+      - .github/workflows/*.y?ml
 
 permissions:
   id-token: write
@@ -54,10 +56,28 @@ jobs:
     - name: Run TFLint
       run: tflint -f compact
 
+  trivy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: tflint
+
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout source code
+
+    - name: Run Trivy config scan
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        scan-type: 'config'
+        scan-ref: '.'
+        format: 'table'
+        exit-code: '1'
+        severity: 'CRITICAL,HIGH'
+
   terraform:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: tflint
+    needs: [tflint, trivy]
     environment:
       name: dev
     defaults:

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# AVD-AZU-0016 (MEDIUM): Vault does not have purge protection enabled.
+AVD-AZU-0016

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,2 @@
 # AVD-AZU-0016 (MEDIUM): Vault does not have purge protection enabled.
-AVD-AZU-0016
+# AVD-AZU-0016

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,2 @@
 # AVD-AZU-0016 (MEDIUM): Vault does not have purge protection enabled.
-# AVD-AZU-0016
+AVD-AZU-0016

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "key_vault" {
     soft_delete_retention_days    = 7
     public_network_access_enabled = true
     network_acls = {
-      default_action             = "Allow"
+      default_action             = "Deny"
       bypass                     = "AzureServices"
       ip_rules                   = ["MyIP"]
       virtual_network_subnet_ids = []

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "key_vault" {
     soft_delete_retention_days    = 7
     public_network_access_enabled = true
     network_acls = {
-      default_action             = "Deny"
+      default_action             = "Allow"
       bypass                     = "AzureServices"
       ip_rules                   = ["MyIP"]
       virtual_network_subnet_ids = []


### PR DESCRIPTION
## 概要

TerraformワークフローにTrivyセキュリティスキャンを統合し、Infrastructure as Code (IaC) の脆弱性を自動検出する機能を追加しました。スキャン結果はGitHub Security Tabsにアップロードされ、CRITICALまたはHIGH severity の脆弱性が検出された場合はワークフローが失敗します。

## 変更内容

### 1. Trivyスキャンジョブの追加
- `aquasecurity/trivy-action@0.28.0` を使用したセキュリティスキャンを実装
- SARIF形式で結果を出力し、GitHub Security Tabsにアップロード
- CRITICAL/HIGH severity の脆弱性検出時にワークフローを失敗させる仕組みを導入

### 2. ワークフロー権限の追加
- `security-events: write` 権限を追加し、SARIF結果のアップロードを許可

### 3. ワークフロートリガーの改善
- ワークフローファイル自体の変更（`*.yml`, `*.yaml`）もトリガー対象に追加

### 4. ジョブ依存関係の更新
- `terraform` ジョブが `trivy` ジョブに依存するよう変更
- セキュリティチェックを通過しない場合は deploy を実行しない

### 5. .trivyignore の追加
- `AVD-AZU-0016` (Vault purge protection) をMEDIUM severityとして除外

## スキャン結果の確認方法

1. **GitHub Security Tabs**
   - リポジトリの「Security」→「Code scanning」タブで詳細を確認
   - 検出された脆弱性の詳細情報、推奨される修正方法を表示

2. **ワークフロー実行ログ**
   - Actions タブから各実行の詳細ログを確認可能

## テスト内容

- [x] Key Vault の `network_acls.default_action` を `"Allow"` に変更して脆弱性を意図的に発生させ、Trivyが正しく検出することを確認
- [x] スキャン結果がGitHub Security Tabsに正しくアップロードされることを確認
- [x] CRITICAL/HIGH脆弱性検出時にワークフローが失敗することを確認
- [x] `.trivyignore` による除外設定が正しく機能することを確認

## 参考

- [Trivy Action](https://github.com/aquasecurity/trivy-action)
- [GitHub Code Scanning](https://docs.github.com/en/code-security/code-scanning)

## チェックリスト

- [x] コードの動作確認を完了した
- [x] セキュリティスキャンが正常に動作することを確認した
- [x] ワークフロー権限が適切に設定されている
- [x] 既存の機能に影響がないことを確認した
